### PR TITLE
Files need to be closed after writing

### DIFF
--- a/Analysis/Benchmarks/Benchmark.cs
+++ b/Analysis/Benchmarks/Benchmark.cs
@@ -229,7 +229,7 @@ namespace NMF.Benchmarks
             stopwatch.Start();
             LoadRoot(options);
             stopwatch.Stop();
-            Report(null, "Load", stopwatch.ElapsedMilliseconds, options);
+            Report(null, "Load", stopwatch.Elapsed.TotalMilliseconds, options);
 
             foreach (var job in Analyzers)
             {
@@ -237,7 +237,7 @@ namespace NMF.Benchmarks
                 stopwatch.Restart();
                 job.Initialize(options);
                 stopwatch.Stop();
-                Report(job.Name, "Initialize", stopwatch.ElapsedMilliseconds, options);
+                Report(job.Name, "Initialize", stopwatch.Elapsed.TotalMilliseconds, options);
 
                 if (i == 0 && options.Memory)
                 {
@@ -247,7 +247,7 @@ namespace NMF.Benchmarks
                 stopwatch.Restart();
                 job.AnalyzeAndReport(options);
                 stopwatch.Stop();
-                Report(job.Name, "Validate", stopwatch.ElapsedMilliseconds, options);
+                Report(job.Name, "Validate", stopwatch.Elapsed.TotalMilliseconds, options);
             }
 
             if (Modifier != null)
@@ -259,7 +259,7 @@ namespace NMF.Benchmarks
                     stopwatch.Restart();
                     Modifier(j);
                     stopwatch.Stop();
-                    Report(null, "Modify", stopwatch.ElapsedMilliseconds, options);
+                    Report(null, "Modify", stopwatch.Elapsed.TotalMilliseconds, options);
 
                     foreach (var job in Analyzers)
                     {
@@ -267,7 +267,7 @@ namespace NMF.Benchmarks
                         var reportAction = job.AnalyzeAndReport(options);
                         stopwatch.Stop();
                         reportAction();
-                        Report(job.Name, "Revalidate", stopwatch.ElapsedMilliseconds, options);
+                        Report(job.Name, "Revalidate", stopwatch.Elapsed.TotalMilliseconds, options);
                     }
                 }
             }

--- a/Analysis/Benchmarks/Benchmark.cs
+++ b/Analysis/Benchmarks/Benchmark.cs
@@ -152,6 +152,15 @@ namespace NMF.Benchmarks
             {
                 RunBenchmark(i, options);
             }
+
+            if (Log != null)
+            {
+                Log.Close();
+            }
+            if (Reporting != null)
+            {
+                Reporting.Close();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
When closing files it is ensured, that the write buffer is flushed.

Best practice would be framing with "using" directives. At the end of the
using block, the close call is done automatically. But no time right now.

Lennart and I had problems with this. The proposed fix resolved those problems