### PR TITLE
Fixed cyclic dependency when an element's old model is the element's new model

### DIFF
--- a/Models/Models/ModelElement.cs
+++ b/Models/Models/ModelElement.cs
@@ -67,7 +67,7 @@ namespace NMF.Models
                     if (oldParent != null)
                     {
                         oldParent.Deleted -= CascadeDelete;
-                        if (EnforceModels && oldModel != null && oldModel == oldParent.Parent)
+                        if (EnforceModels && oldModel != null && oldModel == oldParent.Parent && oldModel != newModel)
                         {
                             oldModel.RootElements.Add(newParent);
                         }


### PR DESCRIPTION
The current implementation added in 0cb5ddecc6e2ab57b9f95bed4a602f910bf448a1 caused a cyclic dependency in the RouteSensor test case. Not 100% sure if this fix works correct in all cases, please double-check.