### PR TITLE
Added robustness and tests for SerializationInformation.SerializationName

### DIFF
--- a/Interop/EcoreInterop.Tests/EcoreInterop.Tests.csproj
+++ b/Interop/EcoreInterop.Tests/EcoreInterop.Tests.csproj
@@ -31,6 +31,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="EcoreXMLSchemaTest.ecore">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="XMLTypeTest.ecore">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Interop/EcoreInterop.Tests/EcoreXMLSchemaTest.cs
+++ b/Interop/EcoreInterop.Tests/EcoreXMLSchemaTest.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using NMF.Models.Meta;
+using NMF.Tests;
+using NMF.Transformations;
+using System.CodeDom;
+using NMF.Models.Repository.Serialization;
+using NMF.Models;
+using System;
+
+namespace NMF.Interop.Ecore.Tests
+{
+    [TestClass]
+    public class EcoreXMLSchemaTest
+    {
+        private INamespace ns;
+
+        [TestMethod]
+        public void TestSerializedName()
+        {
+            EPackage package = EcoreInterop.LoadPackageFromFile("EcoreXMLSchemaTest.ecore");
+            Assert.IsNotNull(package);
+
+            ns = EcoreInterop.Transform2Meta(package);
+            Assert.IsNotNull(ns);
+            
+            /* Check Types */
+            var AnnotationDefaultsType = ns.Types.OfType<IClass>().FirstOrDefault(t => t.Name == "AnnotationDefaultsType");
+            AssertSerializationName(AnnotationDefaultsType, "AnnotationDefaults");
+
+            var PType = ns.Types.OfType<IClass>().FirstOrDefault(t => t.Name == "PType");
+            AssertSerializationName(PType, "P");
+
+            var ModelInformation = ns.Types.OfType<IClass>().FirstOrDefault(t => t.Name == "ModelInformation");
+            AssertNoSerializationName(ModelInformation);
+
+            /* Check References */
+            var pRef = AnnotationDefaultsType.References.FirstOrDefault(r => r.Name == "p");
+            AssertSerializationName(pRef, "P");
+
+            /* Check Attributes */
+            var valueAttr = PType.Attributes.FirstOrDefault(a => a.Name == "value");
+            AssertNoSerializationName(valueAttr);
+
+            var sizeAttr = PType.Attributes.FirstOrDefault(a => a.Name == "size");
+            AssertSerializationName(sizeAttr, "size");
+
+            var mixedAttr = ModelInformation.Attributes.FirstOrDefault(a => a.Name == "mixed");
+            AssertNoSerializationName(mixedAttr);
+        }
+
+        private void AssertSerializationName(IMetaElement type, string serializedName)
+        {
+            Assert.IsNotNull(type);
+            var serializationInfo = type.GetExtension<SerializationInformation>();
+            Assert.IsNotNull(serializationInfo);
+            Assert.AreEqual(serializationInfo.SerializationName, serializedName);
+        }
+
+        private void AssertNoSerializationName(IMetaElement type)
+        {
+            Assert.IsNotNull(type);
+            var serializationInfo = type.GetExtension<SerializationInformation>();
+            Assert.IsNull(serializationInfo);
+        }
+    }
+}

--- a/Interop/EcoreInterop.Tests/EcoreXMLSchemaTest.ecore
+++ b/Interop/EcoreInterop.Tests/EcoreXMLSchemaTest.ecore
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="EcoreXMLSchemaTest" nsURI="">
+  <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+    <details key="qualified" value="false"/>
+  </eAnnotations>
+  <eClassifiers xsi:type="ecore:EClass" name="AnnotationDefaultsType">
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value="AnnotationDefaults_._type"/>
+      <details key="kind" value="elementOnly"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="p" upperBound="-1" eType="#//PType"
+        containment="true" resolveProxies="false">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="element"/>
+        <details key="name" value="P"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="PType">
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value="P_._type"/>
+      <details key="kind" value="simple"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value=":0"/>
+        <details key="kind" value="simple"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="size" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="name" value="size"/>
+        <details key="kind" value="attribute"/>
+        <details key="namespace" value="##targetNamespace"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="ModelInformation">
+    <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+      <details key="name" value=""/>
+      <details key="kind" value="mixed"/>
+    </eAnnotations>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="mixed" unique="false" upperBound="-1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EFeatureMapEntry">
+      <eAnnotations source="http:///org/eclipse/emf/ecore/util/ExtendedMetaData">
+        <details key="kind" value="elementWildcard"/>
+        <details key="name" value=":mixed"/>
+      </eAnnotations>
+    </eStructuralFeatures>
+  </eClassifiers>
+</ecore:EPackage>

--- a/Interop/EcoreInterop/Transformations/Ecore2MetaTransformation.cs
+++ b/Interop/EcoreInterop/Transformations/Ecore2MetaTransformation.cs
@@ -60,10 +60,13 @@ namespace NMF.Interop.Ecore.Transformations
                         var name = extendedMetaData.Details.FirstOrDefault(o => o.Key.Equals("name"));
                         if (name != null)
                         {
-                            output.Extensions.Add(new SerializationInformation(output)
+                            if (!string.IsNullOrEmpty(name.Value) && !name.Value.Contains(":"))
                             {
-                                SerializationName = name.Value.Replace("_._type", "")
-                            });
+                                output.Extensions.Add(new SerializationInformation(output)
+                                {
+                                    SerializationName = name.Value.Replace("_._type", "")
+                                });
+                            }
                         }
                     }
                 }

--- a/Transformations/Models.MetaTransformation/Meta/Attribute2Property.cs
+++ b/Transformations/Models.MetaTransformation/Meta/Attribute2Property.cs
@@ -196,9 +196,16 @@ namespace NMF.Models.Meta
 
             private void GenerateSerializationAttributes(IAttribute input, CodeMemberProperty output, ITransformationContext context)
             {
-                if (input.Name != output.Name)
+                var serializationName = input.Name;
+                var serializationInfo = input.GetExtension<SerializationInformation>();
+                if (serializationInfo != null)
                 {
-                    output.AddAttribute(typeof(XmlElementNameAttribute), input.Name);
+                    serializationName = serializationInfo.SerializationName;
+                }
+
+                if (serializationName != output.Name)
+                {
+                    output.AddAttribute(typeof(XmlElementNameAttribute), serializationName);
                 }
 
                 IClass ownedClass = input.DeclaringType as IClass;

--- a/Transformations/Models.MetaTransformation/Meta/Reference2Property.cs
+++ b/Transformations/Models.MetaTransformation/Meta/Reference2Property.cs
@@ -461,7 +461,6 @@ namespace NMF.Models.Meta
                 codeProperty.HasSet = true;
             }
 
-
             private static void GenerateResetMethod(CodeMemberProperty generatedProperty)
             {
                 var resetMember = new CodeMemberMethod()
@@ -487,9 +486,16 @@ namespace NMF.Models.Meta
 
             private void GenerateSerializationAttributes(IReference input, CodeMemberProperty output, ITransformationContext context)
             {
-                if (input.Name != output.Name)
+                var serializationName = input.Name;
+                var serializationInfo = input.GetExtension<SerializationInformation>();
+                if (serializationInfo != null)
                 {
-                    output.AddAttribute(typeof(XmlElementNameAttribute), input.Name);
+                    serializationName = serializationInfo.SerializationName;
+                }
+
+                if (serializationName != output.Name)
+                {
+                    output.AddAttribute(typeof(XmlElementNameAttribute), serializationName);
                 }
 
                 if (input.IsContainment)


### PR DESCRIPTION
Protected against EAnnotation names that are empty or not used for serialization
Added processing of SerializationInformation name for property creation from references and attributes
Added tests for SerializationInformation generation for types, references, and attributes