### PR TITLE
Fixed ObservableTopX when starting with an empty collection

### DIFF
--- a/Expressions/Expressions.Linq/Linq/ObservableTopX.cs
+++ b/Expressions/Expressions.Linq/Linq/ObservableTopX.cs
@@ -96,7 +96,7 @@ namespace NMF.Expressions.Linq
                 {
                     if (en.MoveNext())
                     {
-                        if (!comparer.Equals(value[i], en.Current))
+                        if (value.Length <= i || !comparer.Equals(value[i], en.Current))
                         {
                             if (newValue == null)
                             {
@@ -116,10 +116,15 @@ namespace NMF.Expressions.Linq
                         {
                             return UnchangedNotificationResult.Instance;
                         }
-                        else
+                        else if (newValue == null)
                         {
                             newValue = new TItem[i];
-                            Array.Copy(oldValue, 0, newValue, 0, i);
+                            Array.Copy(value, 0, newValue, 0, i);
+                            break;
+                        }
+                        else
+                        {
+                            Array.Resize(ref newValue, i);
                             break;
                         }
                     }

--- a/Expressions/Tests/Expressions.Linq.Tests/TopXTests.cs
+++ b/Expressions/Tests/Expressions.Linq.Tests/TopXTests.cs
@@ -110,6 +110,55 @@ namespace NMF.Expressions.Linq.Tests
             Assert.AreEqual(42, topEx.Value[2].Item);
         }
 
+        [TestMethod]
+        public void TopX_EmptyMultipleAdd_CorrectResult()
+        {
+            var collection = new NotifyCollection<Dummy<int>>();
+            var top1 = new Dummy<int>(43);
+            var top2 = new Dummy<int>(42);
+            var top3 = new Dummy<int>(30);
+
+            var changed = false;
+            var topEx = Observable.Expression(() => collection.TopX(3, d => d.Item));
+            topEx.ValueChanged += (sender, args) => changed = true;
+
+            var top = topEx.Value;
+            Assert.AreEqual(0, top.Length);
+
+            collection.Add(top2);
+            top = topEx.Value;
+
+            Assert.IsTrue(changed);
+            Assert.AreEqual(top2, top[0]);
+            Assert.AreEqual(1, top.Length);
+
+            changed = false;
+            collection.Add(top1);
+            collection.Add(top3);
+            top = topEx.Value;
+
+            Assert.IsTrue(changed);
+            Assert.AreEqual(top1, top[0]);
+            Assert.AreEqual(top2, top[1]);
+            Assert.AreEqual(top3, top[2]);
+            Assert.AreEqual(3, top.Length);
+
+            changed = false;
+            collection.Add(new Dummy<int>(22));
+
+            Assert.IsFalse(changed);
+            Assert.AreEqual(top, topEx.Value);
+
+            var newTop3 = new Dummy<int>((top3.Item + top2.Item) / 2);
+            collection.Add(newTop3);
+            top = topEx.Value;
+
+            Assert.IsTrue(changed);
+            Assert.AreEqual(top1, top[0]);
+            Assert.AreEqual(top2, top[1]);
+            Assert.AreEqual(newTop3, top[2]);
+            Assert.AreEqual(3, top.Length);
+        }
 
         [TestMethod]
         public void TopX_Remove_CorrectResult()
@@ -190,9 +239,6 @@ namespace NMF.Expressions.Linq.Tests
             Assert.IsTrue(changed);
             Assert.AreEqual(0, topEx.Value.Length);
         }
-
-
-
 
         [TestMethod]
         public void TopX_Change_CorrectResult()


### PR DESCRIPTION
Starting with an empty collection and then adding a new element resulted in an `IndexOutOfRangeException`, when iterating from 0 to `X`. Adding a length check fixed that.

This led to sitations where `value.Length` was not equal to `i`, but `newValue` was not `null`, indicating that a change happened. The behaviour when clearing the collection or starting with an empty collection indicated that the size of the resulting top x array should be equal to `X` or to the count of the source collection, if `X` is greater than the number of elements. So simply returning `newValue` would break this condition. Resizing `newValue` is sufficient, since all elements to `i` in `value` have already been copied to `newValue`, if `newValue` is not `null`.

Added the new test `TopX_EmptyMultipleAdd_CorrectResult` (which initially failed) to check this behavior.