### PR TITLE
Ecore2Code base namespace override and code gen supression

### DIFF
--- a/Transformations/Models.MetaTransformation/Meta/Meta2ClassesTransformation.cs
+++ b/Transformations/Models.MetaTransformation/Meta/Meta2ClassesTransformation.cs
@@ -233,6 +233,11 @@ namespace NMF.Models.Meta
         }
 
         /// <summary>
+        /// Gets the namespace assigned to a model URI
+        /// </summary>
+        public Dictionary<Uri, string> NamespaceMap { get; } = new Dictionary<Uri, string>();
+
+        /// <summary>
         /// Gets or sets a value indicating whether to separate the class implementations, i.e. create a public interface or not
         /// </summary>
         /// <remarks>This value can only be set before the transformation is initialized</remarks>
@@ -265,5 +270,7 @@ namespace NMF.Models.Meta
                 onlyNested = value;
             }
         }
+
+        public bool GenerateForInputOnly { get; set; }
     }
 }

--- a/Transformations/Models.MetaTransformation/Meta/Namespace2CompileUnit.cs
+++ b/Transformations/Models.MetaTransformation/Meta/Namespace2CompileUnit.cs
@@ -39,7 +39,13 @@ namespace NMF.Models.Meta
                 {
                     foreach (var item in context.Trace.TraceAllIn(ns2ns))
                     {
-                        if (AddToCompileUnit(item.GetInput(0) as INamespace, t))
+                        var ns = item.GetInput(0) as INamespace;
+                        if (ns != input && t.GenerateForInputOnly)
+                        {
+                            continue;
+                        }
+
+                        if (AddToCompileUnit(ns, t))
                         {
                             output.Namespaces.Add(item.Output as CodeNamespace);
                         }

--- a/Transformations/Models.MetaTransformation/Meta/Namespace2Namespace.cs
+++ b/Transformations/Models.MetaTransformation/Meta/Namespace2Namespace.cs
@@ -48,7 +48,10 @@ namespace NMF.Models.Meta
                     var t = Transformation as Meta2ClassesTransformation;
                     if (t != null)
                     {
-                        baseName = t.DefaultNamespace;
+                        if (!t.NamespaceMap.TryGetValue(input.Uri, out baseName))
+                        {
+                            baseName = t.DefaultNamespace;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This PR allows the user to optionally specify a base name to be used with a namespace remapping and suppress generation of code for models that are not in the input