### PR TITLE
Using LocalPath instead of AbsolutePath to handle spaces

### DIFF
--- a/Models/Models/Repository/FileLocator.cs
+++ b/Models/Models/Repository/FileLocator.cs
@@ -18,7 +18,7 @@ namespace NMF.Models.Repository
         /// <inheritdoc />
         public bool CanLocate(Uri uri)
         {
-            return uri != null && ((uri.IsAbsoluteUri && uri.IsFile && File.Exists(uri.AbsolutePath)) || (!uri.IsAbsoluteUri && File.Exists(uri.OriginalString)));
+            return uri != null && ((uri.IsAbsoluteUri && uri.IsFile && File.Exists(uri.LocalPath)) || (!uri.IsAbsoluteUri && File.Exists(uri.OriginalString)));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Currently NMF cannot handle spaces in file paths. With this very small change I was able to load files with paths that contain spaces.