### PR TITLE
support recoveries

### DIFF
--- a/AnyText/AnyText.Core/DiagnosticItem.cs
+++ b/AnyText/AnyText.Core/DiagnosticItem.cs
@@ -55,7 +55,7 @@ namespace NMF.AnyText
         /// <summary>
         /// Gets the length of the error
         /// </summary>
-        public ParsePositionDelta Length => RuleApplication.Length;
+        public virtual ParsePositionDelta Length => RuleApplication.Length;
 
         /// <summary>
         /// Gets the error message

--- a/AnyText/AnyText.Core/Matcher.cs
+++ b/AnyText/AnyText.Core/Matcher.cs
@@ -380,11 +380,20 @@ namespace NMF.AnyText
             var position = new ParsePosition(0, 0);
             MoveOverWhitespaceAndComments(context, ref position);
             var match = MatchCore(context.RootRule, null, context, ref position);
+            while (position.Line < context.Input.Length)
+            {
+                var recovery = match.Recover(match, context, out position);
+                if (recovery == match || recovery.Length == match.Length)
+                {
+                    break;
+                }
+                match = recovery;
+            }
             if (!match.IsPositive || position.Line == context.Input.Length)
             {
                 return match;
             }
-            var unexpected = new UnexpectedContentApplication(context.RootRule, match, new ParsePositionDelta(position.Line, position.Col), "Unexpected content");
+            var unexpected = new FailedParseApplication(context.RootRule, match, new ParsePositionDelta(position.Line, position.Col), "Unexpected content");
             unexpected.SetColumn(GetLine(position.Line).GetOrCreateColumn(position.Col));
             return unexpected;
         }

--- a/AnyText/AnyText.Core/Model/EnumRule.cs
+++ b/AnyText/AnyText.Core/Model/EnumRule.cs
@@ -49,7 +49,7 @@ namespace NMF.AnyText.Model
         }
 
         /// <inheritdoc />
-        protected override RuleApplication CreateRuleApplication(RuleApplication match, ParsePositionDelta examined)
+        protected internal override RuleApplication CreateRuleApplication(RuleApplication match, ParsePositionDelta examined)
         {
             return new EnumRuleApplication(this, match, match.Length, examined);
         }

--- a/AnyText/AnyText.Core/Parser.cs
+++ b/AnyText/AnyText.Core/Parser.cs
@@ -69,7 +69,7 @@ namespace NMF.AnyText
             _matcher.Reset();
             var ruleApplication = _matcher.Match(_context);
             _context.RootRuleApplication = ruleApplication;
-            if (ruleApplication.IsPositive)
+            if (ruleApplication.IsPositive && !ruleApplication.IsRecovered)
             {
                 _context.RefreshRoot();
                 ruleApplication.Activate(_context);
@@ -146,7 +146,7 @@ namespace NMF.AnyText
         {
             _context.Input = input;
             var newRoot = _matcher.Match(_context);
-            if (newRoot.IsPositive)
+            if (newRoot.IsPositive && !newRoot.IsRecovered)
             {
                 if (_context.LastSuccessfulRootRuleApplication != null)
                 {

--- a/AnyText/AnyText.Core/PrettyPrinting/PrettyPrintWriter.cs
+++ b/AnyText/AnyText.Core/PrettyPrinting/PrettyPrintWriter.cs
@@ -90,5 +90,20 @@ namespace NMF.AnyText.PrettyPrinting
             _lastWasNewline = true;
             _writeSpace = false;
         }
+
+        /// <summary>
+        /// Writes raw (unformatted) text
+        /// </summary>
+        /// <param name="text">the unformatted text</param>
+        public void WriteRaw(string text)
+        {
+            if (_lastWasNewline)
+            {
+                _inner.WriteLine();
+            }
+            _inner.Write(text);
+            _lastWasNewline = false;
+            _writeSpace = false;
+        }
     }
 }

--- a/AnyText/AnyText.Core/Rules/ChoiceRule.cs
+++ b/AnyText/AnyText.Core/Rules/ChoiceRule.cs
@@ -151,7 +151,7 @@ namespace NMF.AnyText.Rules
         /// <param name="match">the matched candidate</param>
         /// <param name="examined">the amount of text examined</param>
         /// <returns>a new rule application</returns>
-        protected virtual RuleApplication CreateRuleApplication(RuleApplication match, ParsePositionDelta examined)
+        protected internal virtual RuleApplication CreateRuleApplication(RuleApplication match, ParsePositionDelta examined)
         {
             return new SingleRuleApplication(this, match, match.Length, examined);
         }

--- a/AnyText/AnyText.Core/Rules/FailedChoiceRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/FailedChoiceRuleApplication.cs
@@ -37,6 +37,26 @@ namespace NMF.AnyText.Rules
             return suggestions;
         }
 
+        public override RuleApplication Recover(RuleApplication currentRoot, ParseContext context, out ParsePosition position)
+        {
+            if (Rule is ChoiceRule choice)
+            {
+                for (var i = 0; i < choice.Alternatives.Length; i++)
+                {
+                    var fail = _innerFailures.First(app => app.Rule == choice.Alternatives[i].Rule);
+                    var recovery = fail.Recover(currentRoot, context, out position);
+                    if (recovery.IsPositive)
+                    {
+                        var recovered = choice.CreateRuleApplication(recovery, ParsePositionDelta.Larger(ExaminedTo, recovery.ExaminedTo)).SetRecovered(true);
+                        ReplaceWith(recovered);
+                        return recovered;
+                    }
+                }
+            }
+            position = CurrentPosition;
+            return this;
+        }
+
         /// <inheritdoc />
         public override bool IsPositive => false;
 

--- a/AnyText/AnyText.Core/Rules/FailedParseApplication.cs
+++ b/AnyText/AnyText.Core/Rules/FailedParseApplication.cs
@@ -6,22 +6,25 @@ using System.Threading.Tasks;
 
 namespace NMF.AnyText.Rules
 {
-    internal class UnexpectedContentApplication : FailedRuleApplication
+    internal class FailedParseApplication : FailedRuleApplication
     {
         private readonly RuleApplication _inner;
 
-        public UnexpectedContentApplication(Rule rule, RuleApplication inner, ParsePositionDelta examinedTo, string message) : base(rule, examinedTo, message)
+        public FailedParseApplication(Rule rule, RuleApplication inner, ParsePositionDelta examinedTo, string message) : base(rule, examinedTo, message)
         {
             _inner = inner;
         }
-
-        internal override bool IsUnexpectedContent => true;
 
         public override IEnumerable<RuleApplication> Children => Enumerable.Repeat(_inner, 1);
 
         internal override IEnumerable<CompletionEntry> SuggestCompletions(ParsePosition position, string fragment, ParseContext context, ParsePosition nextTokenPosition)
         {
             return _inner.SuggestCompletions(position, fragment, context, nextTokenPosition);
+        }
+
+        public override RuleApplication Recover(RuleApplication currentRoot, ParseContext context, out ParsePosition position)
+        {
+            return _inner.Recover(currentRoot, context, out position);
         }
 
         public override void IterateLiterals(Action<LiteralRuleApplication> action)

--- a/AnyText/AnyText.Core/Rules/InheritedFailRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/InheritedFailRuleApplication.cs
@@ -9,7 +9,7 @@ namespace NMF.AnyText.Rules
 {
     internal class InheritedFailRuleApplication : RuleApplication
     {
-        private RuleApplication _innerFail;
+        protected RuleApplication _innerFail;
 
         public InheritedFailRuleApplication(Rule rule, RuleApplication inner, ParsePositionDelta examinedTo) : base(rule, inner.Length, examinedTo)
         {
@@ -39,6 +39,17 @@ namespace NMF.AnyText.Rules
                 _innerFail = inn._innerFail;
             }
             return this;
+        }
+
+        public override RuleApplication Recover(RuleApplication currentRoot, ParseContext context, out ParsePosition position)
+        {
+            var recovered = Rule.Recover(this, _innerFail, currentRoot, context, out position);
+            if (recovered.IsPositive)
+            {
+                recovered.SetRecovered(true);
+                ReplaceWith(recovered);
+            }
+            return recovered;
         }
 
         public override IEnumerable<DiagnosticItem> CreateParseErrors()

--- a/AnyText/AnyText.Core/Rules/QuoteRule.cs
+++ b/AnyText/AnyText.Core/Rules/QuoteRule.cs
@@ -42,6 +42,17 @@ namespace NMF.AnyText.Rules
             return new InheritedFailRuleApplication(this, app, app.ExaminedTo);
         }
 
+        /// <inheritdoc />
+        protected internal override RuleApplication Recover(RuleApplication ruleApplication, RuleApplication failedRuleApplication, RuleApplication currentRoot, ParseContext context, out ParsePosition position)
+        {
+            var recovery = failedRuleApplication.Recover(currentRoot, context, out position);
+            if (recovery.IsPositive)
+            {
+                return CreateRuleApplication(recovery, context);
+            }
+            return ruleApplication;
+        }
+
         internal override MatchOrMatchProcessor NextMatchProcessor(ParseContext context, RecursionContext recursionContext, ref ParsePosition position)
         {
             return new MatchOrMatchProcessor(new QuoteMatchProcessor(this));

--- a/AnyText/AnyText.Core/Rules/RecoveredSequenceRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/RecoveredSequenceRuleApplication.cs
@@ -1,0 +1,133 @@
+﻿using NMF.AnyText.PrettyPrinting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NMF.AnyText.Rules
+{
+    internal class RecoveredSequenceRuleApplication : RuleApplication
+    {
+        private readonly List<RuleApplication> _successfulApplications;
+        private readonly RuleApplication _innerFail;
+        private readonly LiteralRuleApplication _stopper;
+
+        public RecoveredSequenceRuleApplication(Rule rule, List<RuleApplication> successfulApplications, RuleApplication innerFail, LiteralRuleApplication stopper, ParsePositionDelta length, ParsePositionDelta examinedTo) : base(rule, length, examinedTo)
+        {
+            _successfulApplications = successfulApplications;
+            _stopper = stopper;
+            _innerFail = innerFail;
+
+            SetRecovered(true);
+        }
+
+        public override RuleApplication ApplyTo(RuleApplication other, ParseContext context)
+        {
+            return other;
+        }
+
+        public override IEnumerable<DiagnosticItem> CreateParseErrors()
+        {
+            return _innerFail.CreateParseErrors().Select(AdjustError);
+        }
+
+        private DiagnosticItem AdjustError(DiagnosticItem error)
+        {
+            var length = _stopper.CurrentPosition - _innerFail.CurrentPosition;
+            return new CustomLengthDiagnosticItem(error.Source, _innerFail, length, $"Failed to parse content: {error.Message}", error.Severity);
+        }
+
+        private class CustomLengthDiagnosticItem : DiagnosticItem
+        {
+            public CustomLengthDiagnosticItem(string source, RuleApplication ruleApplication, ParsePositionDelta length, string message, DiagnosticSeverity severity = DiagnosticSeverity.Error) : base(source, ruleApplication, message, severity)
+            {
+                _length = length;
+            }
+
+            private readonly ParsePositionDelta _length;
+
+            public override ParsePositionDelta Length => _length;
+        }
+
+        public override LiteralRuleApplication GetFirstInnerLiteral()
+        {
+            for (int i = 0; i < _successfulApplications.Count; i++)
+            {
+                var first = _successfulApplications[i].GetFirstInnerLiteral();
+                if (first != null)
+                {
+                    return first;
+                }
+            }
+            return _stopper;
+        }
+
+        public override LiteralRuleApplication GetLastInnerLiteral()
+        {
+            return _stopper;
+        }
+
+        public override RuleApplication GetLiteralAt(ParsePosition position)
+        {
+            for (int i = 0; i < _successfulApplications.Count; i++)
+            {
+                var literal = _successfulApplications[i].GetLiteralAt(position);
+                if (literal != null)
+                {
+                    return literal;
+                }
+            }
+            return null;
+        }
+
+        public override object GetValue(ParseContext context)
+        {
+            return null;
+        }
+
+        public override void IterateLiterals(Action<LiteralRuleApplication> action)
+        {
+            for (int i = 0; i < _successfulApplications.Count; i++)
+            {
+                _successfulApplications[i].IterateLiterals(action);
+            }
+            action?.Invoke(_stopper);
+        }
+
+        public override void IterateLiterals<T>(Action<LiteralRuleApplication, T> action, T parameter)
+        {
+            for (int i = 0; i < _successfulApplications.Count; i++)
+            {
+                _successfulApplications[i].IterateLiterals(action, parameter);
+            }
+            action?.Invoke(_stopper, parameter);
+        }
+
+        public override void Write(PrettyPrintWriter writer, ParseContext context)
+        {
+            var lastPos = CurrentPosition;
+            for (int i = 0; i < _successfulApplications.Count; i++)
+            {
+                _successfulApplications[i].Write(writer, context);
+                lastPos = _successfulApplications[i].CurrentPosition + _successfulApplications[i].Length;
+            }
+
+            var lineNo = lastPos.Line;
+            var col = lastPos.Col;
+
+            while (lineNo < _stopper.CurrentPosition.Line)
+            {
+                writer.WriteRaw(context.Input[lineNo].Substring(col));
+                writer.WriteNewLine();
+                lineNo++;
+                col = 0;
+            }
+
+            writer.WriteRaw(context.Input[lineNo].Substring(0, _stopper.CurrentPosition.Col));
+
+            _stopper.Write(writer, context);
+        }
+
+    }
+}

--- a/AnyText/AnyText.Core/Rules/Rule.cs
+++ b/AnyText/AnyText.Core/Rules/Rule.cs
@@ -58,6 +58,21 @@ namespace NMF.AnyText.Rules
         protected internal virtual void OnDeactivate(RuleApplication application, ParseContext context) { }
 
         /// <summary>
+        /// Recovers from the given inner failed rule application
+        /// </summary>
+        /// <param name="ruleApplication">the rule application that should be recovered</param>
+        /// <param name="failedRuleApplication">the inner rule application that caused the failure</param>
+        /// <param name="currentRoot">the current root rule application</param>
+        /// <param name="context">the parse context in which the rule application is recovered</param>
+        /// <param name="position">the position after the recovery</param>
+        /// <returns>the recovered rule application if the recovery was successful or the old rule application if not</returns>
+        protected internal virtual RuleApplication Recover(RuleApplication ruleApplication, RuleApplication failedRuleApplication, RuleApplication currentRoot, ParseContext context, out ParsePosition position)
+        {
+            position = ruleApplication.CurrentPosition;
+            return ruleApplication;
+        }
+
+        /// <summary>
         /// Gets called when the value of a rule application changes
         /// </summary>
         /// <param name="application">the rule application for which the value changed</param>

--- a/AnyText/AnyText.Core/Rules/RuleHelper.cs
+++ b/AnyText/AnyText.Core/Rules/RuleHelper.cs
@@ -19,7 +19,7 @@ namespace NMF.AnyText.Rules
             }
         }
 
-        public static RuleApplication Star(ParseContext context, RecursionContext recursionContext, Rule rule, List<RuleApplication> applications, ParsePosition referencePosition, Func<RuleApplication, List<RuleApplication>, ParseContext, bool> guard, ref ParsePosition position, ref ParsePositionDelta examined)
+        public static RuleApplication Star(ParseContext context, RecursionContext recursionContext, Rule rule, List<RuleApplication> applications, ParsePosition referencePosition, Func<RuleApplication, List<RuleApplication>, ParseContext, bool> guard, ref ParsePosition position, ref ParsePositionDelta examined, ref bool isRecovered)
         {
             var savedPosition = position;
             RuleApplication app;
@@ -30,6 +30,7 @@ namespace NMF.AnyText.Rules
                 examined = ParsePositionDelta.Larger(examined, appExamined);
                 if (app.IsPositive && guard(app, applications, context))
                 {
+                    isRecovered |= app.IsRecovered;
                     applications.Add(app);
                     savedPosition = position;
                 }

--- a/AnyText/AnyText.Core/Rules/SingleRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/SingleRuleApplication.cs
@@ -17,6 +17,7 @@ namespace NMF.AnyText.Rules
             if (inner != null)
             {
                 inner.Parent = this;
+                IsRecovered = inner.IsRecovered;
             }
         }
 

--- a/AnyText/AnyText.Core/Rules/ZeroOrMoreRule.cs
+++ b/AnyText/AnyText.Core/Rules/ZeroOrMoreRule.cs
@@ -89,8 +89,9 @@ namespace NMF.AnyText.Rules
             var savedPosition = position;
             var applications = new List<RuleApplication>();
             var examined = new ParsePositionDelta();
-            var fail = RuleHelper.Star(context, recursionContext, InnerRule, applications, savedPosition, Accept, ref position, ref examined);
-            return new StarRuleApplication(this, applications, fail, position - savedPosition, examined);
+            var isRecovered = false;
+            var fail = RuleHelper.Star(context, recursionContext, InnerRule, applications, savedPosition, Accept, ref position, ref examined, ref isRecovered);
+            return new StarRuleApplication(this, applications, fail, position - savedPosition, examined).SetRecovered(isRecovered);
         }
 
         /// <summary>

--- a/AnyText/AnyText.Lsp/LspServer.Diagnostics.cs
+++ b/AnyText/AnyText.Lsp/LspServer.Diagnostics.cs
@@ -14,7 +14,7 @@ namespace NMF.AnyText
         {
             var diagnostics = new List<Diagnostic>();
             var errors = context.Errors;
-            foreach (var error in errors.Where(e => e.Message != null))
+            foreach (var error in errors.Where(e => e.Message != null && e.Position.Line < context.Input.Length))
             {                
                 var diagnostic = new Diagnostic()
                 {

--- a/AnyText/AnyText.history
+++ b/AnyText/AnyText.history
@@ -21,3 +21,4 @@ component NMF-AnyText-LSP.nuspec from AnyText.Lsp/Properties/AssemblyInfo.cs
 component ../Tools/NMF-AnyTextGen.nuspec from ../Tools/AnyTextGen/Properties/AssemblyInfo.cs
 
 patch (2.0.457): Start using EtiCat
+minor: Support recoveries

--- a/AnyText/Tests/AnyText.Tests/Features/RecoveryTests.cs
+++ b/AnyText/Tests/AnyText.Tests/Features/RecoveryTests.cs
@@ -1,0 +1,93 @@
+﻿using NMF.AnyText;
+using NMF.AnyText.Grammars;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AnyText.Tests.Features
+{
+    [TestFixture]
+    public class RecoveryTests
+    {
+        [Test]
+        public void AnyText_RecoveryFirstRuleWorks()
+        {
+            var anyText = new AnyTextGrammar();
+            var parser = new Parser(new ModelParseContext(anyText));
+
+            var grammar = @"grammar HelloWorld root Model
+Model: ???????   ???;
+Person:
+    'person' name=ID;
+Greeting:
+    'Hello' person=[Person] '!';
+terminal ID: /[_a-zA-Z][\w_]*/;";
+
+            parser.Initialize(TestUtils.SplitIntoLines(grammar));
+
+            var tokens = new HashSet<string>();
+            parser.Context.RootRuleApplication.IterateLiterals(lit => tokens.Add(lit.Literal));
+
+            Assert.That(tokens.Contains("Person"));
+
+            var errors = parser.Context.Errors.ToList();
+            Assert.That(errors, Is.Not.Empty);
+        }
+
+        [Test]
+        public void AnyText_RecoverySecondRuleWorks()
+        {
+            var anyText = new AnyTextGrammar();
+            var parser = new Parser(new ModelParseContext(anyText));
+
+            var grammar = @"grammar HelloWorld root Model
+Model:
+    (persons+=Person | greetings+=Greeting)*;
+Person:
+    ???????   ???;
+Greeting:
+    'Hello' person=[Person] '!';
+terminal ID: /[_a-zA-Z][\w_]*/;";
+
+            parser.Initialize(TestUtils.SplitIntoLines(grammar));
+
+            var tokens = new HashSet<string>();
+            parser.Context.RootRuleApplication.IterateLiterals(lit => tokens.Add(lit.Literal));
+
+            Assert.That(tokens.Contains("Greeting"));
+
+            var errors = parser.Context.Errors.ToList();
+            Assert.That(errors, Is.Not.Empty);
+        }
+
+
+        [Test]
+        public void AnyText_RecoveryTwoRulesWorks()
+        {
+            var anyText = new AnyTextGrammar();
+            var parser = new Parser(new ModelParseContext(anyText));
+
+            var grammar = @"grammar HelloWorld root Model
+Model:
+    ???????   ???;
+Person:
+    ???????   ???;
+Greeting:
+    'Hello' person=[Person] '!';
+terminal ID: /[_a-zA-Z][\w_]*/;";
+
+            parser.Initialize(TestUtils.SplitIntoLines(grammar));
+
+            var tokens = new HashSet<string>();
+            parser.Context.RootRuleApplication.IterateLiterals(lit => tokens.Add(lit.Literal));
+
+            Assert.That(tokens.Contains("Greeting"));
+
+            var errors = parser.Context.Errors.ToList();
+            Assert.That(errors, Is.Not.Empty);
+        }
+    }
+}


### PR DESCRIPTION
With this change, AnyText detects if a sequence ends with a literal and uses this as a stop token to recover parse errors: if not all text can be parsed, AnyText checks whether the parsing can be resumed from the position of the next-most stop token in order to provide syntax highlighting for such cases.