### PR TITLE
improve error reporting

### DIFF
--- a/AnyText/AnyText.Core/ParsePositionDelta.cs
+++ b/AnyText/AnyText.Core/ParsePositionDelta.cs
@@ -1,11 +1,13 @@
-﻿namespace NMF.AnyText
+﻿using System;
+
+namespace NMF.AnyText
 {
     /// <summary>
     /// Denotes a delta between parser positions
     /// </summary>
     /// <param name="Line">the line delta</param>
     /// <param name="Col">the column delta</param>
-    public record struct ParsePositionDelta(int Line, int Col)
+    public record struct ParsePositionDelta(int Line, int Col) : IComparable<ParsePositionDelta>
     {
         /// <summary>
         /// Calculates the larger of two diffs
@@ -33,6 +35,17 @@
                 return delta2;
             }
             return delta1;
+        }
+
+        /// <inheritdoc />
+        public int CompareTo(ParsePositionDelta other)
+        {
+            var ret = Line.CompareTo(other.Line);
+            if (ret != 0)
+            {
+                return ret; 
+            }
+            return Col.CompareTo(other.Col);
         }
 
         /// <summary>

--- a/AnyText/AnyText.Core/Rules/FailedChoiceRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/FailedChoiceRuleApplication.cs
@@ -40,10 +40,8 @@ namespace NMF.AnyText.Rules
         {
             if (Rule is ChoiceRule choice)
             {
-                for (var i = 0; i < choice.Alternatives.Length; i++)
+                foreach (var fail in _innerFailures.OrderByDescending(f => f.ExaminedTo))
                 {
-                    var fail = _innerFailures.FirstOrDefault(app => app.Rule == choice.Alternatives[i].Rule);
-                    if (fail == null) continue; 
                     var recovery = fail.Recover(currentRoot, context, out position);
                     if (recovery.IsPositive)
                     {

--- a/AnyText/AnyText.Core/Rules/FailedSequenceRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/FailedSequenceRuleApplication.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NMF.AnyText.Rules
 {
@@ -94,6 +95,10 @@ namespace NMF.AnyText.Rules
 
         public override void AddParseErrors(ParseContext context)
         {
+            if (_successfulApplications.Count > 0)
+            {
+                _successfulApplications.Last().AddParseErrors(context);
+            }
             if (_furtherFails != null)
             {
                 foreach (var fail in _furtherFails)

--- a/AnyText/AnyText.Core/Rules/StarRuleApplication.cs
+++ b/AnyText/AnyText.Core/Rules/StarRuleApplication.cs
@@ -29,7 +29,10 @@ namespace NMF.AnyText.Rules
 
         public override void AddParseErrors(ParseContext context)
         {
-            Stopper?.AddParseErrors(context);
+            if (Stopper != null && Stopper.CurrentPosition.Line < context.Input.Length)
+            {
+                Stopper.AddParseErrors(context);
+            }
             base.AddParseErrors(context);
         }
 

--- a/AnyText/AnyText.Generator/Transformation/AnytextCodeGenerator.cs
+++ b/AnyText/AnyText.Generator/Transformation/AnytextCodeGenerator.cs
@@ -180,6 +180,8 @@ namespace NMF.AnyText.Transformation
                     return choiceExpression;
                 case INegativeLookaheadExpression negative:
                     return new CodeObjectCreateExpression(typeof(NegativeLookaheadRule).ToTypeReference(), CreateParserExpression(negative.Inner, negative.FormattingInstructions, ruleTransformation, assignTransformation, context));
+                case IPositiveLookaheadExpression positive:
+                    return new CodeObjectCreateExpression(typeof(PositiveLookaheadRule).ToTypeReference(), CreateParserExpression(positive.Inner, positive.FormattingInstructions, ruleTransformation, assignTransformation, context));
             }
             throw new NotSupportedException();
         }
@@ -1077,6 +1079,7 @@ namespace NMF.AnyText.Transformation
 
             private static CodeMemberMethod CreateGetValue(IAssignExpression input, CodeTypeReference semanticType, CodeTypeReference propertyType, CodeArgumentReferenceExpression semanticElementRef, CodePropertyReferenceExpression property)
             {
+                var feature = CodeGenerator._trace.LookupFeature(input);
                 var getValue = new CodeMemberMethod
                 {
                     Name = "GetValue",
@@ -1094,6 +1097,10 @@ namespace NMF.AnyText.Transformation
                     ["context"] = "the parsing context"
                 });
                 CodeExpression getValueReturn = property;
+                if (feature != null && feature.LowerBound == 0 && input.Assigned is RuleExpression ruleExpression && ruleExpression.Rule is EnumRule)
+                {
+                    getValueReturn = new CodeMethodInvokeExpression(getValueReturn, nameof(Nullable<int>.GetValueOrDefault));
+                }
                 getValue.Statements.Add(new CodeMethodReturnStatement(getValueReturn));
                 return getValue;
             }

--- a/AnyText/AnyText.history
+++ b/AnyText/AnyText.history
@@ -48,3 +48,4 @@ patch: improve code lenses for synchronizations
 major: changed extension API for indentation-aware, create API to propagate context changes
 patch: do not check whether rule application is memoized if it is only interesting to see whether the line is obsolete
 patch: adapt metamodel code to changed interface
+patch: improve error reporting


### PR DESCRIPTION
<!-- MergeMonkey[summary]:start -->
## Summary by MergeMonkey
- **Fresh Additions:**
  - Added IComparable implementation to ParsePositionDelta for proper ordering of position deltas
  - Added positive lookahead expression handling in code generation for complete expression support
  - Improved error recovery logic by ordering failures by examined position descending
- **Corrections:**
  - Added bounds check in StarRuleApplication to prevent errors when Stopper position exceeds input length
  - Improved error propagation in FailedSequenceRuleApplication by calling AddParseErrors on last successful application
  - Added nullable enum value handling in GetValue to call GetValueOrDefault when lower bound is zero
- **Chores:**
  - Added System.Linq import to FailedSequenceRuleApplication for OrderByDescending operation
<!-- MergeMonkey[summary]:end -->