### PR TITLE
patch: fix type copy for operations without return type

### DIFF
--- a/Interop/EcoreInterop.history
+++ b/Interop/EcoreInterop.history
@@ -9,3 +9,4 @@ patch (2.0.457): Start using EtiCat
 patch: Add support for .NET 10
 patch: adapt metamodel code to changed interface
 patch: fix type mappings, copy types imported from elsewhere into generated package
+patch: fix type copy for operations without return type

--- a/Interop/EcoreInterop/Transformations/Ecore2MetaTransformation.cs
+++ b/Interop/EcoreInterop/Transformations/Ecore2MetaTransformation.cs
@@ -405,7 +405,7 @@ namespace NMF.Interop.Ecore.Transformations
                 output.UpperBound = input.UpperBound.GetValueOrDefault(1);
 
                 // type could be loaded from external resources, make sure the transformed type is registered somewhere
-                if (output.Type.Parent == null && output.Ancestors().OfType<IType>().FirstOrDefault() is var enclosingType && enclosingType?.Namespace != null)
+                if (output.Type != null && output.Type.Parent == null && output.Ancestors().OfType<IType>().FirstOrDefault() is var enclosingType && enclosingType?.Namespace != null)
                 {
                     enclosingType.Namespace.Types.Add(output.Type);
                 }

--- a/Tools/Ecore2Code.history
+++ b/Tools/Ecore2Code.history
@@ -13,3 +13,4 @@ patch: Add option to save NMeta metamodel
 patch: adapt to models interface
 patch: update system dependencies
 patch: fix type mappings, copy types imported from elsewhere into generated package
+patch: fix type copy for operations without return type


### PR DESCRIPTION
<!-- MergeMonkey[summary]:start -->
## Summary by MergeMonkey
- **Squashed Bugs:**
  - Fixes null reference when copying types for operations without return type
<!-- MergeMonkey[summary]:end -->