### PR TITLE
Obfuscation friendly metamodel registry

### DIFF
--- a/Models/Models.history
+++ b/Models/Models.history
@@ -20,3 +20,4 @@ patch: store all elements with global name, including conflicts
 patch: debugging improvements
 major: improve code generation for child elements
 patch: make model collection observable, update dependencies
+minor: allow to override how model metadata is loaded

--- a/Models/Models/ModelMetadataAttribute.cs
+++ b/Models/Models/ModelMetadataAttribute.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace NMF.Models
 {
@@ -35,6 +38,41 @@ namespace NMF.Models
                 ModelUri = new Uri(modelUri, UriKind.Relative);
             }
             ResourceName = resourceName;
+        }
+
+        /// <summary>
+        /// Loads the manifest stream containing the metamodel from the given assembly and resource names. If the resource name is not found, an exception is thrown.
+        /// </summary>
+        /// <param name="assembly">The assembly to which this attribute is attached</param>
+        /// <param name="resourceNames">the resource names available for the given assembly</param>
+        /// <returns>A stream containing the metamodel described by this instance</returns>
+        public virtual Stream LoadMetamodel(Assembly assembly, string[] resourceNames)
+        {
+            var actualResourceName = FindResourceName(assembly, resourceNames);
+            return assembly.GetManifestResourceStream(actualResourceName);
+        }
+
+        private string FindResourceName(Assembly assembly, string[] names)
+        {
+            var resourceName = ResourceName;
+            if (!names.Contains(ResourceName))
+            {
+                var resources = names.Where(n => n.EndsWith(resourceName)).ToList();
+                if (resources.Count == 1)
+                {
+                    resourceName = resources[0];
+                }
+                else if (resources.Count == 0)
+                {
+                    throw new InvalidOperationException($"Embedded resource {resourceName} was not found in assembly {assembly.FullName}.");
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Multiple embedded resources with the suffix {resourceName} were found in {assembly.FullName}.");
+                }
+            }
+
+            return resourceName;
         }
     }
 }

--- a/Models/Models/Repository/MetaRepository.cs
+++ b/Models/Models/Repository/MetaRepository.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Reflection;
 using NMF.Models.Repository.Serialization;
 using NMF.Models.Meta;
+using System.IO;
 
 namespace NMF.Models.Repository
 {
@@ -188,15 +189,14 @@ namespace NMF.Models.Repository
                     for (int i = 0; i < attributes.Length; i++)
                     {
                         var metadata = attributes[i] as ModelMetadataAttribute;
-                        string resourceName = FindResourceName(assembly, names, metadata);
                         if (metadata.ModelUri.IsAbsoluteUri)
                         {
 #if DEBUG
-                            LoadModel(assembly, attributes, i, resourceName, metadata.ModelUri);
+                            LoadModel(metadata.LoadMetamodel(assembly, names), attributes, i, metadata.ResourceName, metadata.ModelUri);
 #else
                         try
                         {
-                            LoadModel(assembly, attributes, i, resourceName, metadata.ModelUri);
+                            LoadModel(metadata.LoadMetamodel(assembly, names), attributes, i, metadata.ResourceName, metadata.ModelUri);
                         }
                         catch (Exception e)
                         {
@@ -211,7 +211,7 @@ namespace NMF.Models.Repository
                         }
                         else
                         {
-                            throw new InvalidOperationException($"The declared embedded resource {metadata.ResourceName} of assembly {assembly.FullName} could not be found.");
+                            throw new InvalidOperationException($"The model URI {metadata.ModelUri} is not an absolute URI.");
                         }
                     }
                     AddMappedTypeExtensions(saveMapping);
@@ -234,29 +234,6 @@ namespace NMF.Models.Repository
                     throw new InvalidOperationException(string.Format("The class {0} could not be resolved.", saveMapping[i].Key));
                 }
             }
-        }
-
-        private static string FindResourceName(Assembly assembly, string[] names, ModelMetadataAttribute metadata)
-        {
-            var resourceName = metadata.ResourceName;
-            if (!names.Contains(metadata.ResourceName))
-            {
-                var resources = names.Where(n => n.EndsWith(resourceName)).ToList();
-                if (resources.Count == 1)
-                {
-                    resourceName = resources[0];
-                }
-                else if (resources.Count == 0)
-                {
-                    throw new InvalidOperationException($"Embedded resource {resourceName} was not found in assembly {assembly.FullName}.");
-                }
-                else
-                {
-                    throw new InvalidOperationException($"Multiple embedded resources with the suffix {resourceName} were found in {assembly.FullName}.");
-                }
-            }
-
-            return resourceName;
         }
 
         private void InitSaveMappings(System.Type[] types, List<KeyValuePair<string, System.Type>> saveMapping)
@@ -301,9 +278,14 @@ namespace NMF.Models.Repository
             }
         }
 
-        private void LoadModel(Assembly assembly, object[] attributes, int i, string resourceName, Uri modelUri)
+        private void LoadModel(Stream resourceStream, object[] attributes, int i, string resourceName, Uri modelUri)
         {
-            var model = serializer.Deserialize(assembly.GetManifestResourceStream(resourceName), modelUri, this, true);
+            if (resourceStream == null)
+            {
+                return;
+            }
+
+            var model = serializer.Deserialize(resourceStream, modelUri, this, true);
             for (int j = i + 1; j < attributes.Length; j++)
             {
                 if (attributes[j] is ModelMetadataAttribute followingAttribute)


### PR DESCRIPTION
Rationale
----------

By default, model metadata is loaded from plain embedded resources, but there is a demand to encrypt them or otherwise protect the embedded resources.

Design
-------

Loading models from embedded resources is moved into `ModelMetadataAttribute` and made virtual such that custom code can override the method `LoadMetamodel` in order to return whatever stream they like, including streams that decrypt the metamodel sources on the fly.

---
<!-- MergeMonkey[summary]:start -->
## Summary by MergeMonkey
- **Docs & Guides:**
  - Updated version history to document the new obfuscation-friendly metadata loading capability
- **Enhancements:**
  - Added virtual LoadMetamodel method to ModelMetadataAttribute enabling custom resource loading for encrypted/obfuscated metamodels
- **Corrections:**
  - Fixed incorrect error message in MetaRepository - was reporting resource not found when the actual issue was non-absolute URI
<!-- MergeMonkey[summary]:end -->